### PR TITLE
Add dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,104 @@
+# [os] OS & editor files
+**/Desktop.ini
+**/Thumbs.db
+**/._*
+**/*.DS_Store
+**/*~
+**/\#*\#
+**/.AppleDouble
+**/.LSOverride
+**/.spelling
+**/.vscode
+**/*.swp
+**/.ropeproject
+.idea
+
+# Virtual environment
+env/
+env[23]/
+.env/
+.venv/
+venv/
+.Python
+.envrc
+
+# Data, compiled, build or log files
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+logs/
+lib64/
+parts/
+sdist/
+var/
+_site/
+**/*.*.map
+*.egg-info/
+.installed.cfg
+*.egg
+pip-log.txt
+pip-delete-this-directory.txt
+pids
+*.pid
+*.seed
+.*-metadata
+**/*.sqlite
+**/*.sqlite3
+**/*-cache/
+**/*.log
+**/*.bak
+**/*.manifest
+**/*.spec
+**/__pycache__/
+**/*.py[cod]
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Deliberately ignore certain project files
+# ==
+
+# Readmes
+README.md
+HACKING.md
+
+# The run script
+run
+.docker-project
+.*.hash
+
+# Node is only needed for building, not running
+package.json
+node_modules
+yarn.lock
+
+# Git, travis, docker
+.git
+.gitignore
+.travis.yml
+docker-compose.yml
+.docker
+
+# Sphinx documentation
+docs/_build/
+
+# Local dependencies
+.bundle/
+node_modules/
+vendor/
+bower_components/
+package-lock.json
+yarn.lock
+bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:xenial
+
+# System dependencies
+RUN apt-get update && apt-get install --yes python3-pip
+
+# Python dependencies
+ENV LANG C.UTF-8
+RUN pip3 install --upgrade pip
+RUN pip3 install gunicorn
+
+# Set git commit ID
+ARG COMMIT_ID
+ENV COMMIT_ID=${COMMIT_ID}
+RUN test -n "${COMMIT_ID}"
+
+# Import code, install code dependencies
+WORKDIR /srv
+ADD . .
+RUN pip3 install -r requirements.txt
+
+# Setup commands to run server
+ENTRYPOINT ["gunicorn", "app:app", "--access-logfile", "-", "--error-logfile", "-", "--bind"]
+CMD ["0.0.0.0:80"]


### PR DESCRIPTION
**Please review this PR first** https://github.com/canonical-docs/conjure-up-docs/pull/27

Add dockerfile to build image for serving the app.

## QA
- Build site content: `./run build`
- Build: `docker build --tag conjure-up-docs . --build-arg COMMIT_ID=$(git rev-parse HEAD)`
- Start server: `docker run --rm -p 8204:80 -it conjure-up-docs`
- Check the website and images correctly show at http://localhost:8204