### PR TITLE
New homepage + update documentation-builder to 1.6.0

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -1,303 +1,59 @@
-Title: conjure-up | User manual
-TODO: Needs a considerable overhaul
-      Document should be renamed
-table_of_contents: True
-
-# User Manual
-
-**conjure-up** is a thin layer spanning a few different underlying technologies
-- [Juju][juju], [MAAS][maas] and [LXD][lxd].
-
-**conjure-up** provides you with a streamlined, turnkey solution. In order to
-provide that streamlined approach, **conjure-up** makes use of processing
-scripts.
-
-Processing scripts give you the flexibility to alter LXD profiles in order to
-expose additional network interfaces to Neutron services, import images into
-Glance once the service is available, or notifying the Deployment status screen
-that your solution is ready and can be viewed at a specific URL.
-
-With these powerful concepts you can package up the solution that can then be
-provided to coworkers who can easily deploy your solutions in any Public
-Cloud, MAAS, or LXD.
-
-## Getting started
-
-## Hardware requirements
-
-For **Public Cloud** deployments hardware requirements (*constraints*) are
-handled by the Spell authors and will automatically be allocated during deploy.
-
-For **localhost** deployments the following setup is recommended:
-
-- 2 cores
-- 16G RAM
-- 32G Swap
-- 250G SSD
-
-## Update your system
-
-It is always recommended to have the latest packages installed prior to running `conjure-up`:
-
-```
-sudo apt update
-sudo apt upgrade
-```
-
-## Installing conjure-up
-
-`conjure-up` is available on Ubuntu Xenial 16.04 LTS and macOS
-
-### Ubuntu
-```bash
-sudo snap install conjure-up --classic
-```
-!!! Note:
-    If above command fails you’ll want to make sure **snapd** is installed with
-    `sudo apt install snapd`
-
-### macOS
-```
-brew install conjure-up
-```
-
-## Upcoming releases
-
-If you want to preview of the next release, the latest beta version can be
-installed with the following command:
-
-```bash
-sudo snap install conjure-up --classic --beta
-```
-
-For the most recent changes, install the `edge` release:
-
-```bash
-sudo snap install conjure-up --classic --edge
-```
-
-If you have **conjure-up** already installed, you can update to a different
-snap channel with:
-
-```bash
-sudo snap refresh conjure-up --classic --edge
-```
-or
-
-```
-sudo snap refresh conjure-up --classic --beta
-```
-
-## Users of LXD
-
-**conjure-up** requires that the minimum version of LXD be **3.0.0**. Additionally,
-LXD should be configured prior to running.
-
-### Install LXD
-
-To install LXD run the following:
-
-```
-sudo snap install lxd
-/snap/bin/lxd init  #  Notice there is NO __sudo__ prepended here.
-```
-
-[Snaps][snappy] are the recommended installation method. In upcoming Ubuntu
-releases the snap version of LXD will be the only recommended way of installing
-and using LXD. For the best experience, it is recommended to migrate from the **deb**
-LXD packaging:
-
-
-```
-/snap/bin/lxd.migrate
-```
-
-This will move all container specific data to the snap version and clean up the
-unused debian packages.
-
-
-**Ubuntu for Desktops**
-
-In order to access the LXD service your **$USER** will need to be apart of the
-**lxd** group. To add your **$USER** to lxd group perform the following:
-
-
-
-```
-sudo usermod -a -G lxd $USER
-newgrp lxd
-```
-
-!!! Note:
-    This only allows the current shell to have access to the **lxd**
-    group. The recommended way is to completely logout of your system so that the
-    **lxd** group can be properly applied.
-
-**Ubuntu for Servers**
-
-By default, Ubuntu Server has the **lxd** group associated with your default
-**$USER**. To verify, run the following:
-
-```
-id
-uid=1000(ubuntu) gid=1000(ubuntu) groups=1000(ubuntu),4(adm),27(sudo),129(lxd)
-
-```
-
-If not, simply re-run the `usermod` and `newgrp` commands:
-
-```
-sudo usermod -a -G lxd $USER
-newgrp lxd
-```
-
-### LXD Storage
-
-At least one storage pool must be created and the default profile be set to use that storage device:
-
-```
-/snap/bin/lxc storage list
-```
-
-```
-+---------+-------------+--------+------------------------------------------------+---------+
-|  NAME   | DESCRIPTION | DRIVER |                     SOURCE                     | USED BY |
-+---------+-------------+--------+------------------------------------------------+---------+
-| default |             | dir    | /var/snap/lxd/common/lxd/storage-pools/default | 1       |
-+---------+-------------+--------+------------------------------------------------+---------+
-```
-
-```
-/snap/bin/lxc storage show default
-```
-
-```
-config:
-  source: /var/snap/lxd/common/lxd/storage-pools/default
-description: ""
-name: default
-driver: dir
-used_by:
-- /1.0/profiles/default
-```
-!!! Note:
-    If you are planning on deploying Kubernetes onto LXD via the localhost
-    provider, please see the [limitations section][k8slimitation] of the
-    **Kubernetes Spellbook**.
-
-### LXD Networking
-
-For localhost deployments, LXD must have a network bridge defined:
-
-```
-/snap/bin/lxc network create lxdbr0 ipv4.address=auto ipv4.nat=true ipv6.address=none ipv6.nat=false
-```
-
-!!! Note:
-    conjure-up does not support IPv6 at this time.
-
-To verify that a bridge is configured properly you will need to inspect the config:
-
-```
-/snap/bin/lxc network show lxdbr0
-```
-
-```
-config:
-  ipv4.address: 10.101.64.1/24
-  ipv4.nat: "true"
-  ipv6.address: none
-  ipv6.nat: "false"
-description: ""
-name: lxdbr0
-type: bridge
-used_by: []
-managed: true
-```
-
-You will also want to make sure that the LXD default profile is set to use **lxdbr0** as its bridge:
-
-```
-/snap/bin/lxc profile show default
-```
-
-```
-config: {}
-description: Default LXD profile
-devices:
-  eth0:
-    nictype: bridged
-    parent: lxdbr0
-    type: nic
-  root:
-    path: /
-    pool: default
-    type: disk
-name: default
-used_by: []
-```
-
-!!! Note:
-    If this is a brand new LXD install and your profile does not look like the
-    one above, run `/snap/bin/lxc profile edit default` and make the necessary
-    adjustments.
-
-### Verify container creation and network accessibility
-
-```
-lxc launch ubuntu:16.04 u1
-lxc exec u1 ping ubuntu.com
-```
-
-Once satisfied your container can reach out to the internet, you can stop and remove that container:
-
-```
-lxc stop u1
-lxc delete u1
-```
-
-
-## Summon a Spell
-
-To deploy solutions such as Kubernetes you will summon a spell:
-
-```bash
-conjure-up kubernetes
-```
-
-To see a list of all available spells run:
-
-```bash
-conjure-up
-```
-
-!!! Note:
-    Several remote locations are supported - please see [Advanced Spell
-    Summoning][advancedspells] for further details
-
-## Uninstalling
-
-To remove deployments:
-
-```bash
-conjure-down
-```
-
-To uninstall **conjure-up** itself:
-
-```bash
-sudo snap remove conjure-up
-```
-
-<!-- LINKS -->
-[juju]: https://jujucharms.com
-[maas]: https://maas.io/
-[lxd]: https://linuxcontainers.org/lxd/
-[trusty]: http://releases.ubuntu.com/14.04/
-[xenial]: http://releases.ubuntu.com/16.04/
-[snappy]: https://snapcraft.io/
-[applist]: ./index.md#application-list
-[advancedspells]: ./usage.md
-[k8slimitation]: ./spellbooks/kubernetes.md#limitations
-
-<!-- IMAGES -->
+---
+title: Home
+homepage: true
+---
+
+<div class="p-strip--image" style="background-image: url('https://assets.ubuntu.com/v1/4a3a6943-background.png')">
+    <div class="p-content__row">
+        <div class="col-8">
+            <h1>What is conjure-up</h1>
+            <p class="p-heading--four" style="max-width: 35em">Conjure-up is a tool to deploy complex applications with the minimum of fuss. Working on top of technologies like Juju and MAAS, you can go from nothing to a fully working OpenStack, hadoop, Kubernetes and more in minutes</p>
+        </div>
+    </div>
+</div>
+<div class="p-strip">
+    <div class="p-content__row">
+        <div class="u-equal-height">
+            <div class="col-6">
+                <h2>Getting started</h2>
+                <h3>Deploy the Canonical Distribution of Kubernetes</h3>
+                <p>Try this guide to see how easy deploying complex applications can be!</p>
+                <a href="/en/walkthrough">Quick link&nbsp;&rsaquo;</a>
+            </div>
+            <div class="col-6">
+                <img style="max-height: 20rem; padding: 1rem 5rem;" src="https://assets.ubuntu.com/v1/b108a74b-kubernetes-1-left.png">
+            </div>
+        </div>
+        <hr class="is-deep">
+        <div class="u-equal-height">
+            <div class="col-6">
+                <h2>Getting support</h2>
+                <ul class="p-list">
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/d3ae9c8e-irc-icon-circle.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="http://webchat.freenode.net/?channels=%23conjure-up">Find us on irc at #conjure-up</a>
+                    </li>
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/4d7dbd0c-icon-settings.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a href="/en/troubleshoot">Check through the troubleshooting guide</a>
+                    </li>
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="https://askubuntu.com/questions/tagged/conjure-up?_ga=2.164186168.660465880.1529311292-549686022.1524126781">Ask a question</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="col-6">
+                <h2>Contribute</h2>
+                <ul class="p-list">
+                    <li class="p-list__item"><a class="p-link--external" href="https://github.com/canonical-docs/conjure-up-docs">Improve the docs</a></li>
+                    <li class="p-list__item--deep"><a href="/en/dev-manual">Make a spell</a></li>
+                    <li class="p-list__item"><a class="p-link--external" href="https://github.com/conjure-up/conjure-up">Hack on conjure-up</a></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>

--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -1,31 +1,35 @@
 navigation:
- - title: User Manual
+ - title: Home
    location: index.md
 
+ - title: User Manual
    children:
 
+    - title: Overview
+      location: user-manual.md
+
     - title: Getting started
-      location: index.md#getting-started
+      location: user-manual.md#getting-started
 
       children:
 
             - title: Hardware requirements
-              location: index.md#hardware-requirements
+              location: user-manual.md#hardware-requirements
 
             - title: Installing conjure-up
-              location: index.md#installing-conjure-up
+              location: user-manual.md#installing-conjure-up
 
             - title: Upcoming releases
-              location: index.md#upcoming-releases
+              location: user-manual.md#upcoming-releases
 
             - title: Users of LXD
-              location: index.md#users-of-lxd
+              location: user-manual.md#users-of-lxd
 
             - title: Summon a spell
-              location: index.md#summon-a-spell
+              location: user-manual.md#summon-a-spell
 
             - title: Uninstalling
-              location: index.md#uninstalling
+              location: user-manual.md#uninstalling
 
     - title: Spell walkthrough
       location: walkthrough.md#

--- a/en/user-manual.md
+++ b/en/user-manual.md
@@ -1,0 +1,303 @@
+Title: conjure-up | User manual
+TODO: Needs a considerable overhaul
+      Document should be renamed
+table_of_contents: True
+
+# User Manual
+
+**conjure-up** is a thin layer spanning a few different underlying technologies
+- [Juju][juju], [MAAS][maas] and [LXD][lxd].
+
+**conjure-up** provides you with a streamlined, turnkey solution. In order to
+provide that streamlined approach, **conjure-up** makes use of processing
+scripts.
+
+Processing scripts give you the flexibility to alter LXD profiles in order to
+expose additional network interfaces to Neutron services, import images into
+Glance once the service is available, or notifying the Deployment status screen
+that your solution is ready and can be viewed at a specific URL.
+
+With these powerful concepts you can package up the solution that can then be
+provided to coworkers who can easily deploy your solutions in any Public
+Cloud, MAAS, or LXD.
+
+## Getting started
+
+## Hardware requirements
+
+For **Public Cloud** deployments hardware requirements (*constraints*) are
+handled by the Spell authors and will automatically be allocated during deploy.
+
+For **localhost** deployments the following setup is recommended:
+
+- 2 cores
+- 16G RAM
+- 32G Swap
+- 250G SSD
+
+## Update your system
+
+It is always recommended to have the latest packages installed prior to running `conjure-up`:
+
+```
+sudo apt update
+sudo apt upgrade
+```
+
+## Installing conjure-up
+
+`conjure-up` is available on Ubuntu Xenial 16.04 LTS and macOS
+
+### Ubuntu
+```bash
+sudo snap install conjure-up --classic
+```
+!!! Note:
+    If above command fails you’ll want to make sure **snapd** is installed with
+    `sudo apt install snapd`
+
+### macOS
+```
+brew install conjure-up
+```
+
+## Upcoming releases
+
+If you want to preview of the next release, the latest beta version can be
+installed with the following command:
+
+```bash
+sudo snap install conjure-up --classic --beta
+```
+
+For the most recent changes, install the `edge` release:
+
+```bash
+sudo snap install conjure-up --classic --edge
+```
+
+If you have **conjure-up** already installed, you can update to a different
+snap channel with:
+
+```bash
+sudo snap refresh conjure-up --classic --edge
+```
+or
+
+```
+sudo snap refresh conjure-up --classic --beta
+```
+
+## Users of LXD
+
+**conjure-up** requires that the minimum version of LXD be **3.0.0**. Additionally,
+LXD should be configured prior to running.
+
+### Install LXD
+
+To install LXD run the following:
+
+```
+sudo snap install lxd
+/snap/bin/lxd init  #  Notice there is NO __sudo__ prepended here.
+```
+
+[Snaps][snappy] are the recommended installation method. In upcoming Ubuntu
+releases the snap version of LXD will be the only recommended way of installing
+and using LXD. For the best experience, it is recommended to migrate from the **deb**
+LXD packaging:
+
+
+```
+/snap/bin/lxd.migrate
+```
+
+This will move all container specific data to the snap version and clean up the
+unused debian packages.
+
+
+**Ubuntu for Desktops**
+
+In order to access the LXD service your **$USER** will need to be apart of the
+**lxd** group. To add your **$USER** to lxd group perform the following:
+
+
+
+```
+sudo usermod -a -G lxd $USER
+newgrp lxd
+```
+
+!!! Note:
+    This only allows the current shell to have access to the **lxd**
+    group. The recommended way is to completely logout of your system so that the
+    **lxd** group can be properly applied.
+
+**Ubuntu for Servers**
+
+By default, Ubuntu Server has the **lxd** group associated with your default
+**$USER**. To verify, run the following:
+
+```
+id
+uid=1000(ubuntu) gid=1000(ubuntu) groups=1000(ubuntu),4(adm),27(sudo),129(lxd)
+
+```
+
+If not, simply re-run the `usermod` and `newgrp` commands:
+
+```
+sudo usermod -a -G lxd $USER
+newgrp lxd
+```
+
+### LXD Storage
+
+At least one storage pool must be created and the default profile be set to use that storage device:
+
+```
+/snap/bin/lxc storage list
+```
+
+```
++---------+-------------+--------+------------------------------------------------+---------+
+|  NAME   | DESCRIPTION | DRIVER |                     SOURCE                     | USED BY |
++---------+-------------+--------+------------------------------------------------+---------+
+| default |             | dir    | /var/snap/lxd/common/lxd/storage-pools/default | 1       |
++---------+-------------+--------+------------------------------------------------+---------+
+```
+
+```
+/snap/bin/lxc storage show default
+```
+
+```
+config:
+  source: /var/snap/lxd/common/lxd/storage-pools/default
+description: ""
+name: default
+driver: dir
+used_by:
+- /1.0/profiles/default
+```
+!!! Note:
+    If you are planning on deploying Kubernetes onto LXD via the localhost
+    provider, please see the [limitations section][k8slimitation] of the
+    **Kubernetes Spellbook**.
+
+### LXD Networking
+
+For localhost deployments, LXD must have a network bridge defined:
+
+```
+/snap/bin/lxc network create lxdbr0 ipv4.address=auto ipv4.nat=true ipv6.address=none ipv6.nat=false
+```
+
+!!! Note:
+    conjure-up does not support IPv6 at this time.
+
+To verify that a bridge is configured properly you will need to inspect the config:
+
+```
+/snap/bin/lxc network show lxdbr0
+```
+
+```
+config:
+  ipv4.address: 10.101.64.1/24
+  ipv4.nat: "true"
+  ipv6.address: none
+  ipv6.nat: "false"
+description: ""
+name: lxdbr0
+type: bridge
+used_by: []
+managed: true
+```
+
+You will also want to make sure that the LXD default profile is set to use **lxdbr0** as its bridge:
+
+```
+/snap/bin/lxc profile show default
+```
+
+```
+config: {}
+description: Default LXD profile
+devices:
+  eth0:
+    nictype: bridged
+    parent: lxdbr0
+    type: nic
+  root:
+    path: /
+    pool: default
+    type: disk
+name: default
+used_by: []
+```
+
+!!! Note:
+    If this is a brand new LXD install and your profile does not look like the
+    one above, run `/snap/bin/lxc profile edit default` and make the necessary
+    adjustments.
+
+### Verify container creation and network accessibility
+
+```
+lxc launch ubuntu:16.04 u1
+lxc exec u1 ping ubuntu.com
+```
+
+Once satisfied your container can reach out to the internet, you can stop and remove that container:
+
+```
+lxc stop u1
+lxc delete u1
+```
+
+
+## Summon a Spell
+
+To deploy solutions such as Kubernetes you will summon a spell:
+
+```bash
+conjure-up kubernetes
+```
+
+To see a list of all available spells run:
+
+```bash
+conjure-up
+```
+
+!!! Note:
+    Several remote locations are supported - please see [Advanced Spell
+    Summoning][advancedspells] for further details
+
+## Uninstalling
+
+To remove deployments:
+
+```bash
+conjure-down
+```
+
+To uninstall **conjure-up** itself:
+
+```bash
+sudo snap remove conjure-up
+```
+
+<!-- LINKS -->
+[juju]: https://jujucharms.com
+[maas]: https://maas.io/
+[lxd]: https://linuxcontainers.org/lxd/
+[trusty]: http://releases.ubuntu.com/14.04/
+[xenial]: http://releases.ubuntu.com/16.04/
+[snappy]: https://snapcraft.io/
+[applist]: ./index.md#application-list
+[advancedspells]: ./usage.md
+[k8slimitation]: ./spellbooks/kubernetes.md#limitations
+
+<!-- IMAGES -->

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,2 +1,18 @@
 site_title: Conjure-up documentation
-site_logo_url: 
+site_logo_url: https://assets.ubuntu.com/v1/8c237d84-conjure-up-logo-black.svg
+site_favicon: https://assets.ubuntu.com/v1/cb22ba5d-favicon-16x16.png
+site_remove_navigation_title: true
+
+site_navigation:
+  - title: User manual
+    location: /
+
+  - title: Developer manual
+    location: /dev-manual
+
+site_footer_links:
+  - title: 'Legal information'
+    location: https://www.ubuntu.com/legal
+    
+  - title: 'Report a bug on this site'
+    location: https://github.com/CanonicalLtd/maas-docs/issues/new

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -5,10 +5,10 @@ site_remove_navigation_title: true
 
 site_navigation:
   - title: User manual
-    location: /
+    location: /en
 
   - title: Developer manual
-    location: /dev-manual
+    location: /en/dev-manual
 
 site_footer_links:
   - title: 'Legal information'

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "scripts": {
       "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite build/ .extra templates",
       "watch": "watch -p './**/*.md' -c 'yarn run build-css'",
-      "build": "documentation-builder --base-directory . --output-path templates --output-media-path 'static/media' --media-url '/static/media' --tag-manager-code 'GTM-K92JCQ' --search-domain 'docs.conjure-up.io' --search-url 'https://docs.ubuntu.com/search' --search-placeholder 'Search conjure-up docs' --no-link-extensions --build-version-branches",
+      "build": "documentation-builder --base-directory . --output-path templates --output-media-path 'static/media' --media-url '/static/media' --tag-manager-code 'GTM-K92JCQ' --search-domain 'docs.conjure-up.io' --search-url 'https://docs.ubuntu.com/search' --search-placeholder 'Search conjure-up docs' --no-link-extensions --build-version-branches --site-root https://conjure-up.io/",
       "test": "",
       "serve": "cd dist && FLASK_DEBUG=true FLASK_APP=app.py flask run -h 0.0.0.0 -p $PORT"
     },

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==0.12.2
 PyYAML==3.12
 pycountry==17.9.23
 yamlordereddictloader==0.4.0
-ubuntudesign.documentation-builder==1.5.1
+ubuntudesign.documentation-builder==1.6.0


### PR DESCRIPTION
## Done

- Updated documentation-builder to 1.6.0, which includes Vanilla 1.7.1 styling + some slight adjustments for docs (tighter spacing, wider text max-width etc)
- Updated `metadata.yaml` with favicon, logo url, and conjure-up navigation styles
- Added `--site-root` option to build script so nav logo links to conjure-up.io
- Updated homepage and moved previous one to /user-manual

## QA

- Pull code
- Add branch name to `versions`
- Run `./run`
- Go to http://0.0.0.0:8204
- Select branch from versions dropdown
- Check the new homepage and styling has been applied on this branch
- Check that the other versions still work properly

## Screenshot

![0 0 0 0_8204_devel_en_ 1](https://user-images.githubusercontent.com/25733845/41537178-913d4080-72ff-11e8-84fe-9657a5805f1d.png)

