### PR TITLE
Add net-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV LANG C.UTF-8
 WORKDIR /srv
 
 # System dependencies
-RUN apt-get update && apt-get install --yes nginx
+RUN apt-get update && apt-get install --yes nginx net-tools
 
 # Set git commit ID
 ARG COMMIT_ID


### PR DESCRIPTION
This is so we can use `netstat` in a `livenessProbe` to check a process is running on port 80.